### PR TITLE
Removed secondary default nginx configuration

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -91,6 +91,6 @@ server {
 	#}
 }
 
-    include /etc/nginx/conf.d/*.conf;
+    #include /etc/nginx/conf.d/*.conf;
 }
 


### PR DESCRIPTION
There is a default nginx configuration located in /etc/nginx/conf.d/ that overrides the main nginx.conf file if included at the end. 